### PR TITLE
TLF-317: Incorrect titles on Tenant's details page

### DIFF
--- a/apps/lcs/behaviours/custom-validation.js
+++ b/apps/lcs/behaviours/custom-validation.js
@@ -39,8 +39,6 @@ module.exports = superclass => class extends superclass {
       if(!validators.before(dateToBeValidated, config.startOf1988)) {
         return validationErrorFunc('before');
       }
-      
-      
     }
 
     if(key === 'rental-property-postcode') {

--- a/apps/lcs/behaviours/custom-validation.js
+++ b/apps/lcs/behaviours/custom-validation.js
@@ -1,6 +1,5 @@
 const validators = require('hof/controller/validation/validators');
 const config = require('../../../config.js');
-const dateBefore1988 = config.dateBefore1988;
 
 module.exports = superclass => class extends superclass {
   validateField(key, req) {
@@ -12,6 +11,9 @@ module.exports = superclass => class extends superclass {
 
       if(!dateToBeValidated) {
         return validationErrorFunc('required');
+      }
+      if(!validators.date(dateToBeValidated)) {
+        return validationErrorFunc('date');
       }
       if(tenantMovedIn && !validators.before(dateToBeValidated, tenantMovedIn)) {
         return validationErrorFunc('dobBeforeMovedIn');
@@ -25,9 +27,8 @@ module.exports = superclass => class extends superclass {
       if(!dateToBeValidated) {
         return validationErrorFunc('required');
       }
-      if(req.sessionModel.get('before-or-after-1988') === 'yes'
-      && !validators.before(dateToBeValidated, dateBefore1988)) {
-        return validationErrorFunc('before');
+      if(!validators.date(dateToBeValidated)) {
+        return validationErrorFunc('date');
       }
       if(!validators.after(dateToBeValidated, '120', 'years')) {
         return validationErrorFunc('after120years');
@@ -35,6 +36,11 @@ module.exports = superclass => class extends superclass {
       if(!validators.after(dateToBeValidated, tenantDob)) {
         return validationErrorFunc('dateAfterDob');
       }
+      if(!validators.before(dateToBeValidated, config.startOf1988)) {
+        return validationErrorFunc('before');
+      }
+      
+      
     }
 
     if(key === 'rental-property-postcode') {

--- a/apps/lcs/fields/index.js
+++ b/apps/lcs/fields/index.js
@@ -58,8 +58,6 @@ module.exports = {
   'tenant-dob': dateComponent('tenant-dob', {
     mixin: 'input-date',
     validate: [
-      'required',
-      'date',
       'over18',
       { type: 'after', arguments: ['120', 'years'] }
     ], // additional validation rules added in custom-validation.js
@@ -77,7 +75,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.tenant-nationality.options.none_selected'
-    }].concat(countries),
+    }].concat(countries.filter(country => country.value !== 'United Kingdom')),
     labelClassName: ''
   },
   'ho-ref-number': {
@@ -90,7 +88,7 @@ module.exports = {
     mixin: 'checkbox',
     validate: ['required']
   },
-  'before-or-after-1988': {
+  'in-uk-before-1988': {
     isPageHeading: 'true',
     mixin: 'radio-group',
     validate: 'required',
@@ -106,10 +104,7 @@ module.exports = {
   },
   'date-tenant-moved-uk': dateComponent('date-tenant-moved-uk', {
     mixin: 'input-date',
-    validate: [
-      'required',
-      'date'
-    ], // additional validation rules added in custom-validation.js
+    validate: [], // additional validation rules added in custom-validation.js
     className: ['govuk-label--s']
   }),
   'extra-tenant-pob': {

--- a/apps/lcs/index.js
+++ b/apps/lcs/index.js
@@ -17,10 +17,10 @@ const localsEnricher  = require('./behaviours/locals-enricher');
  * @returns {boolean} - Returns true if the tenant's DOB is before the start of 1988 and not equal to the excluded date.
  */
 function shouldRedirectToBefore1988(tenantDob, startOf1988) {
-  const excludedDate = '1987-12-30';
+  const excludedDate = '1987-12-31';
 
   /**
-   * If the tenant's date of birth is before the cutoff date and not equal to 1987-12-30,
+   * If the tenant's date of birth is before the cutoff date and not equal to 1987-12-31,
    * then redirect to '/before-1988'. This allows tenants born on 1987-12-30 to enter
    * 1987-12-31 as their date of entry to the UK on the '/extra-tenant-details' page and progress.
    */

--- a/apps/lcs/index.js
+++ b/apps/lcs/index.js
@@ -9,6 +9,24 @@ const customRedirect = require('./behaviours/custom-redirect');
 const valuesEnricher = require('./behaviours/values-enricher')(config);
 const localsEnricher  = require('./behaviours/locals-enricher');
 
+/**
+ * Checks if the user should be redirected to the '/before-1988' page based on the tenant's date of birth.
+ *
+ * @param {string} tenantDob - The tenant's date of birth in ISO format.
+ * @param {string} startOf1988 - The start date of 1988 in ISO format.
+ * @returns {boolean} - Returns true if the tenant's DOB is before the start of 1988 and not equal to the excluded date.
+ */
+function shouldRedirectToBefore1988(tenantDob, startOf1988) {
+  const excludedDate = '1987-12-30';
+
+  /**
+   * If the tenant's date of birth is before the cutoff date and not equal to 1987-12-30,
+   * then redirect to '/before-1988'. This allows tenants born on 1987-12-30 to enter
+   * 1987-12-31 as their date of entry to the UK on the '/extra-tenant-details' page and progress.
+   */
+  return tenantDob < startOf1988 && tenantDob !== excludedDate;
+}
+
 const steps =  {
   '/start': {
     next: '/property-occupied'
@@ -49,7 +67,7 @@ const steps =  {
     forks: [
       {
         target: '/before-1988',
-        condition: req => req.sessionModel.get('tenant-dob') < config.startOf1988
+        condition: req => shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'), config.startOf1988)
       }
     ]
   },

--- a/apps/lcs/index.js
+++ b/apps/lcs/index.js
@@ -4,7 +4,6 @@ const config = require('../../config');
 const clearSession = require('./behaviours/clear-session');
 const sendNotification = require('./behaviours/submit-notify');
 const saveDetails = require('./behaviours/saving-details');
-const dateBefore1989 = config.dateBefore1989;
 const customValidation = require('./behaviours/custom-validation.js');
 const customRedirect = require('./behaviours/custom-redirect');
 const valuesEnricher = require('./behaviours/values-enricher')(config);
@@ -50,18 +49,18 @@ const steps =  {
     forks: [
       {
         target: '/before-1988',
-        condition: req => req.sessionModel.get('tenant-dob') <= dateBefore1989
+        condition: req => req.sessionModel.get('tenant-dob') < config.startOf1988
       }
     ]
   },
   '/before-1988': {
-    fields: ['before-or-after-1988'],
+    fields: ['in-uk-before-1988'],
     next: '/extra-tenant-details',
     forks: [
       {
         target: '/landlord-information',
         condition: {
-          field: 'before-or-after-1988',
+          field: 'in-uk-before-1988',
           value: 'no'
         }
       }

--- a/apps/lcs/translations/src/en/fields.json
+++ b/apps/lcs/translations/src/en/fields.json
@@ -14,8 +14,8 @@
     "legend": "When did the tenant move into your property?",
     "hint": "For example 21 3 2015"
   },
-  "before-or-after-1988": {
-      "legend": "Has the prospective tenant been in the UK since before 1988?",
+  "in-uk-before-1988": {
+      "legend": "Has the {{values.valuesEnriched.tenantType}} been in the UK since before 1988?",
       "isPageHeading:": true,
       "className": "govuk-radios govuk-radios--inline",
       "options": {

--- a/apps/lcs/translations/src/en/validation.json
+++ b/apps/lcs/translations/src/en/validation.json
@@ -5,7 +5,7 @@
   "when-person-moved-in": {
     "required": "Tell us when the tenant moved into the property",
     "notUrl": "Your answer must not contain URLs or links",
-    "date": "Enter a real date of birth",
+    "date": "Enter a real date",
     "after": "This service only applies to tenants who moved in after 30 November 2014",
     "before": "This date must not be in the future"
   },

--- a/apps/lcs/translations/src/en/validation.json
+++ b/apps/lcs/translations/src/en/validation.json
@@ -14,12 +14,14 @@
   },
   "tenant-dob": {
     "required": "Enter the {{valuesEnriched.tenantType}}'s date of birth",
+    "date": "Enter a real date of birth",
     "dobBeforeMovedIn": "{{valuesEnriched.tenantType}} cannot be born after they moved into the rental property. Enter a date before {{valuesEnriched.tenantMovedIn}}.",
     "after": "Enter a real date of birth",
     "over18": "The {{valuesEnriched.tenantType}} must be 18 years or older. The right to rent scheme does not apply to children."
   },
   "tenant-nationality": {
-    "required": "Select a country of nationality from the list"
+    "required": "Select a country of nationality from the list",
+    "excludeUK": "You do not need to use this service if the {{valuesEnriched.tenantType}} is a British citizen"
   },
   "ho-ref-number": {
     "required": "Enter a Home Office reference number"
@@ -27,7 +29,7 @@
   "privacy-check": {
     "required": "Confirm you have read the Data Protection statement"
   },
-  "before-or-after-1988": {
+  "in-uk-before-1988": {
     "required": "Tell us whether the {{valuesEnriched.tenantType}} came to the UK before 1988"
   },
   "extra-tenant-pob": {
@@ -41,10 +43,11 @@
     "email": "Enter a real email address"
   },
   "date-tenant-moved-uk": {
-    "required": "Enter a date the tenant came to the UK",
+    "required": "Enter a date the {{valuesEnriched.tenantType}} came to the UK",
+    "date": "Enter a real date",
     "after120years": "Enter a real date the {{valuesEnriched.tenantType}} came to the UK",
     "before": "Date must be before 1988",
-    "dateAfterDob": "Date must be after the {{valuesEnriched.tenantType}}'s date of birth. Enter a date after {{valuesEnriched.tenantDoB}}" 
+    "dateAfterDob": "Date must be after the {{valuesEnriched.tenantType}}'s date of birth. Enter a date after {{valuesEnriched.tenantDoB}}"
   },
   "extra-tenant-tel": {
     "required": "Enter a telephone number",

--- a/apps/lcs/views/check-requested.html
+++ b/apps/lcs/views/check-requested.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$pageTitle}}
-    {{#t}}pages.privacy-declaration.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+    {{#t}}pages.check-requested.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
   {{/pageTitle}}
   {{$page-content}}
     <div class="govuk-panel govuk-panel--confirmation">

--- a/apps/lcs/views/tenant-details.html
+++ b/apps/lcs/views/tenant-details.html
@@ -1,15 +1,12 @@
 {{<partials-page}}
-  {{$pageTitle}}
-    {{#t}}pages.tenant-details{{/t}}
-  {{/pageTitle}}
   {{$page-content}}
-  {{#fields}}
-  {{#renderField}}{{/renderField}}
-  {{/fields}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
 
-  {{#markdown}}what-counts-as-a-home-office-reference-number{{/markdown}}
+    {{#markdown}}what-counts-as-a-home-office-reference-number{{/markdown}}
 
-  {{#input-submit}}continue{{/input-submit}}
+    {{#input-submit}}continue{{/input-submit}}
 
   {{/page-content}}
 {{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -13,6 +13,5 @@ module.exports = {
     port: process.env.REDIS_PORT || '6379',
     host: process.env.REDIS_HOST || '127.0.0.1'
   },
-  dateBefore1988: '1987-12-31',
-  dateBefore1989: '1988-12-31'
+  startOf1988: '1988-01-01'
 };


### PR DESCRIPTION
## What? 
[TLF-317](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-317) Incorrect titles on Tenant details page
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
Various updates also include:
- validation on tenant's nationality ( it now doesn't have the UK in country list)
- label on page /before-1988 (now it's dynamic depending on tenantType)
- move in uk date validation to allow dates < 01.01.1988
- validation rules and error messages for invalid date on all date fields
- change to redirect logic if the user should be redirected to the '/before-1988' page based on the tenant's date of birth
- title on Check requested page has been fixed

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
