### PR TITLE
TLF-326: Upgrade Node and dependency packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+FROM node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
 
 USER root
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ trigger:
 
 linting: &linting
   pull: if-not-exists
-  image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+  image: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -33,7 +33,7 @@ linting: &linting
 
 unit_tests: &unit_tests
   pull: if-not-exists
-  image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+  image: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -64,7 +64,7 @@ steps:
 
   - name: setup_deploy
     pull: if-not-exists
-    image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+    image: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -183,7 +183,7 @@ steps:
 
   - name: setup_branch
     pull: if-not-exists
-    image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+    image: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+FROM node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
 
 USER root
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Request a right to rent check",
   "main": "index.js",
   "engines": {
-    "node": ">=20.16.0 <21.0.0"
+    "node": ">=20.17.0 <21.0.0"
   },
   "scripts": {
     "start": "node server.js",
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/UKHomeOffice/landlords-checking-service#readme",
   "dependencies": {
-    "hof": "^21.0.3",
-    "accessible-autocomplete": "^3.0.0"
+    "hof": "^21.1.1",
+    "accessible-autocomplete": "^3.0.1"
   },
   "devDependencies": {
     "chai": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/UKHomeOffice/landlords-checking-service#readme",
   "dependencies": {
     "hof": "^21.1.1",
-    "accessible-autocomplete": "^3.0.1"
+    "accessible-autocomplete": "^3.0.1",
+    "notifications-node-client": "^8.2.1"
   },
   "devDependencies": {
     "chai": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,10 +466,10 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-accessible-autocomplete@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-3.0.0.tgz#f66ed03fb22d78f721326d187ee491dddbadec75"
-  integrity sha512-Kpm6EX+jjD0AurWfzSP4EVLEKsLUWCazZwidjum+8FCRtSINeaPzVa3ElKVGWvSqVZN9zjeSBF8cirhYEZjW1A==
+accessible-autocomplete@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz#8ddf4934d0b4ba6acb28de486dd505e062cdc86e"
+  integrity sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2680,10 +2680,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^21.0.3:
-  version "21.0.5"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-21.0.5.tgz#1d464bba351104dc7bbdf2c35ee09783c95de2c8"
-  integrity sha512-uT+EcFSaGw4994fGijAE4QLMzVX1rzD++IP3XDnDvyD3VIpqp8AXM0D1ILWRzWYd2RtM19w15VEEvini50rXzA==
+hof@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-21.1.1.tgz#1f70c0a4c30ac82293761541c0524032042da11b"
+  integrity sha512-zQwFIrr4s9ev2ag5Aq4XZUb1agZC8Zw7DzzSqVX/gCen+hseC+swV8jIo5psvjUN8moAVaDDQG1Lwi4j54XzYg==
   dependencies:
     aliasify "^2.1.0"
     axios "^1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,7 +3777,7 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-notifications-node-client@^8.2.0:
+notifications-node-client@^8.2.0, notifications-node-client@^8.2.1:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/notifications-node-client/-/notifications-node-client-8.2.1.tgz#6b3e0d855c675bcb706f0f773e25eb738b46688f"
   integrity sha512-wyZh/NbjN8S2uQX18utYtCyC726BBaGeTc4HeUpdhZv5sYKuaQY94N31v9syh8SzVgehyMzW37y08EePmi+k3Q==


### PR DESCRIPTION
## What? 
[TLF-326](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-326) - LCS - Upgrade Node and dependency packages

- Node.js 20.17.0 ( Alpine 3.20 )
- hof 21.1.1
- accessible-autocomplete 3.0.1
- notifications-node-client 8.2.1
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
