### PR TITLE
TLF-332 - LCS - Added replyToEmailID in the send email method 

### DIFF
--- a/apps/lcs/behaviours/custom-redirect.js
+++ b/apps/lcs/behaviours/custom-redirect.js
@@ -5,14 +5,17 @@ module.exports = superclass => class extends superclass {
     const currentRoute = req.form.options.route;
     const action = req.params.action;
 
-    if (req.sessionModel.get('isCurrentTenant') && currentRoute === '/tenant-address' && action === 'edit') {
-      if(shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob')) &&
-       !req.sessionModel.get('steps').includes('/before-1988')) {
+    if (currentRoute === '/tenant-address' && action === 'edit' && req.sessionModel.get('isCurrentTenant')) {
+      this.emit('complete', req, res);
+      return res.redirect('/rental-property');
+    }
+
+    if (currentRoute === '/tenant-details' && action === 'edit') {
+      if(shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))  &&
+      !req.sessionModel.get('steps').includes('/before-1988')) {
         this.emit('complete', req, res);
         return res.redirect('/before-1988');
       }
-      this.emit('complete', req, res);
-      return res.redirect('/rental-property');
     }
 
     if (currentRoute === '/property-occupied' && action === 'edit') {

--- a/apps/lcs/behaviours/custom-redirect.js
+++ b/apps/lcs/behaviours/custom-redirect.js
@@ -1,9 +1,12 @@
+const config = require('../../../config.js');
+
 module.exports = superclass => class extends superclass {
   successHandler(req, res, next) {
     const currentRoute = req.form.options.route;
     const action = req.params.action;
 
-    if (req.sessionModel.get('isCurrentTenant') && currentRoute === '/tenant-address' && action === 'edit') {
+    if (req.sessionModel.get('isCurrentTenant') && req.sessionModel.get('tenant-dob') > config.startOf1988 &&
+      currentRoute === '/tenant-address' && action === 'edit') {
       this.emit('complete', req, res);
       return res.redirect('/rental-property');
     }

--- a/apps/lcs/behaviours/custom-redirect.js
+++ b/apps/lcs/behaviours/custom-redirect.js
@@ -1,12 +1,16 @@
-const config = require('../../../config.js');
+const { shouldRedirectToBefore1988 } = require('../../../utils/index.js');
 
 module.exports = superclass => class extends superclass {
   successHandler(req, res, next) {
     const currentRoute = req.form.options.route;
     const action = req.params.action;
 
-    if (req.sessionModel.get('isCurrentTenant') && req.sessionModel.get('tenant-dob') > config.startOf1988 &&
-      currentRoute === '/tenant-address' && action === 'edit') {
+    if (req.sessionModel.get('isCurrentTenant') && currentRoute === '/tenant-address' && action === 'edit') {
+      if(shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob')) &&
+       !req.sessionModel.get('steps').includes('/before-1988')) {
+        this.emit('complete', req, res);
+        return res.redirect('/before-1988');
+      }
       this.emit('complete', req, res);
       return res.redirect('/rental-property');
     }

--- a/apps/lcs/behaviours/send-email-notification.js
+++ b/apps/lcs/behaviours/send-email-notification.js
@@ -66,11 +66,13 @@ module.exports = class SendEmailConfirmation {
       const targetTemplate = `${recipientType}ConfirmationTemplateId`;
       const targetEmailAddress = recipientType === 'user' ?
         this.req.sessionModel.get('landlord-or-agent-email') : config.govukNotify.caseworkerEmail;
+      const emailReplyToId = config.govukNotify.replyToEmailID;
       await notifyClient.sendEmail(
         config.govukNotify[targetTemplate],
         targetEmailAddress,
         {
-          personalisation: this.emailPersonalisations
+          personalisation: this.emailPersonalisations,
+          emailReplyToId: emailReplyToId
         }
       );
 

--- a/apps/lcs/fields/index.js
+++ b/apps/lcs/fields/index.js
@@ -80,7 +80,7 @@ module.exports = {
   },
   'ho-ref-number': {
     mixin: 'input-text',
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     labelClassName: '',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
@@ -109,7 +109,7 @@ module.exports = {
   }),
   'extra-tenant-pob': {
     mixin: 'input-text',
-    validate: 'required',
+    validate: ['required', 'notUrl'],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'extra-tenant-ni-num': {
@@ -119,7 +119,7 @@ module.exports = {
   },
   'extra-tenant-email': {
     mixin: 'input-text',
-    validate: 'email',
+    validate: [{ type: 'minlength', arguments: 6 }, { type: 'maxlength', arguments: 254 }, 'email'],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'extra-tenant-tel': {
@@ -129,16 +129,17 @@ module.exports = {
   },
   'tenant-address-line-1': {
     mixins: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 250 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'tenant-address-line-2': {
-    mixins: ['input-text', { type: 'maxlength', arguments: 250 }],
+    mixins: ['input-text'],
+    validate: ['notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'tenant-town-or-city': {
     mixins: 'input-text',
-    validate: 'required',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'tenant-county': {
@@ -150,7 +151,7 @@ module.exports = {
     mixins: 'input-text',
     formatter: ['ukPostcode'],
     validate: ['required', 'postcode'],
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    className: ['govuk-input', 'govuk-input--width-10']
   },
   'landlord-or-agent-name': {
     mixins: 'input-text',
@@ -164,7 +165,7 @@ module.exports = {
   },
   'landlord-or-agent-email': {
     mixins: 'input-text',
-    validate: ['required', 'email'],
+    validate: ['required', { type: 'minlength', arguments: 6 }, { type: 'maxlength', arguments: 254 }, 'email'],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'landlord-or-agent-tel': {

--- a/apps/lcs/index.js
+++ b/apps/lcs/index.js
@@ -27,10 +27,10 @@ const steps =  {
   '/tenant-details': {
     behaviours: [
       hof.components.homeOfficeCountries,
+      customRedirect,
       customValidation,
       valuesEnricher('tenant-dob', 'tenantDoB')
     ],
-    continueOnEdit: true,
     fields: [
       'tenant-full-name',
       'tenant-dob',
@@ -41,7 +41,6 @@ const steps =  {
   },
   '/tenant-address': {
     behaviours: [customRedirect, saveDetails()],
-    continueOnEdit: true,
     fields: [
       'tenant-address-line-1',
       'tenant-address-line-2',

--- a/apps/lcs/index.js
+++ b/apps/lcs/index.js
@@ -8,24 +8,7 @@ const customValidation = require('./behaviours/custom-validation.js');
 const customRedirect = require('./behaviours/custom-redirect');
 const valuesEnricher = require('./behaviours/values-enricher')(config);
 const localsEnricher  = require('./behaviours/locals-enricher');
-
-/**
- * Checks if the user should be redirected to the '/before-1988' page based on the tenant's date of birth.
- *
- * @param {string} tenantDob - The tenant's date of birth in ISO format.
- * @param {string} startOf1988 - The start date of 1988 in ISO format.
- * @returns {boolean} - Returns true if the tenant's DOB is before the start of 1988 and not equal to the excluded date.
- */
-function shouldRedirectToBefore1988(tenantDob, startOf1988) {
-  const excludedDate = '1987-12-31';
-
-  /**
-   * If the tenant's date of birth is before the cutoff date and not equal to 1987-12-31,
-   * then redirect to '/before-1988'. This allows tenants born on 1987-12-30 to enter
-   * 1987-12-31 as their date of entry to the UK on the '/extra-tenant-details' page and progress.
-   */
-  return tenantDob < startOf1988 && tenantDob !== excludedDate;
-}
+const { shouldRedirectToBefore1988 } = require('../../utils');
 
 const steps =  {
   '/start': {
@@ -70,7 +53,7 @@ const steps =  {
     forks: [
       {
         target: '/before-1988',
-        condition: req => shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'), config.startOf1988)
+        condition: req => shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))
       }
     ]
   },

--- a/apps/lcs/sections/summary-data-sections.js
+++ b/apps/lcs/sections/summary-data-sections.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const moment = require('moment');
+const { shouldRedirectToBefore1988 } = require('../../../utils');
 const PRETTY_DATE_FORMAT = 'DD MMMM YYYY';
 
 module.exports = {
@@ -57,6 +58,16 @@ module.exports = {
       {
         step: '/tenant-address',
         field: 'tenant-postcode'
+      },
+      {
+        step: '/before-1988',
+        field: 'in-uk-before-1988',
+        parse: (value, req) => {
+          if (!shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))) {
+            return null;
+          }
+          return value;
+        }
       }
     ]
   },
@@ -64,24 +75,53 @@ module.exports = {
     steps: [
       {
         step: '/extra-tenant-details',
-        field: 'extra-tenant-tel'
+        field: 'extra-tenant-tel',
+        parse: (value, req) => {
+          if (!shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))) {
+            return null;
+          }
+          return value;
+        }
       },
       {
         step: '/extra-tenant-details',
-        field: 'extra-tenant-pob'
+        field: 'extra-tenant-pob',
+        parse: (value, req) => {
+          if (!shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))) {
+            return null;
+          }
+          return value;
+        }
       },
       {
         step: '/extra-tenant-details',
         field: 'date-tenant-moved-uk',
-        parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
+        parse: (value, req) => {
+          if (!shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))) {
+            return null;
+          }
+          return value && moment(value).format(PRETTY_DATE_FORMAT);
+        }
       },
       {
         step: '/extra-tenant-details',
-        field: 'extra-tenant-email'
+        field: 'extra-tenant-email',
+        parse: (value, req) => {
+          if (!shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))) {
+            return null;
+          }
+          return value;
+        }
       },
       {
         step: '/extra-tenant-details',
-        field: 'extra-tenant-ni-num'
+        field: 'extra-tenant-ni-num',
+        parse: (value, req) => {
+          if (!shouldRedirectToBefore1988(req.sessionModel.get('tenant-dob'))) {
+            return null;
+          }
+          return value;
+        }
       }
     ]
   },

--- a/apps/lcs/translations/src/en/fields.json
+++ b/apps/lcs/translations/src/en/fields.json
@@ -81,7 +81,7 @@
     "label": "Postcode"
   },
   "landlord-or-agent-name": {
-    "label": "Landlord or agent's full name"
+    "label": "Landlord's or agent's full name"
   },
   "landlord-or-agent-company": {
     "label": "Company name (optional)"

--- a/apps/lcs/translations/src/en/pages.json
+++ b/apps/lcs/translations/src/en/pages.json
@@ -67,6 +67,9 @@
       },
       "rental-property-postcode": {
         "label": "Rental property postcode"
+      },
+      "in-uk-before-1988": {
+        "label": "Been in the UK since before 1988?"
       }
     }
   },

--- a/apps/lcs/translations/src/en/validation.json
+++ b/apps/lcs/translations/src/en/validation.json
@@ -10,7 +10,8 @@
     "before": "This date must not be in the future"
   },
   "tenant-full-name": {
-    "required": "Enter the {{valuesEnriched.tenantType}}'s full name"
+    "required": "Enter the {{valuesEnriched.tenantType}}'s full name",
+    "notUrl": "Your answer must not contain URLs or links"
   },
   "tenant-dob": {
     "required": "Enter the {{valuesEnriched.tenantType}}'s date of birth",
@@ -24,7 +25,8 @@
     "excludeUK": "You do not need to use this service if the {{valuesEnriched.tenantType}} is a British citizen"
   },
   "ho-ref-number": {
-    "required": "Enter a Home Office reference number"
+    "required": "Enter a Home Office reference number",
+     "notUrl": "Your answer must not contain URLs or links"
   },
   "privacy-check": {
     "required": "Confirm you have read the Data Protection statement"
@@ -33,14 +35,17 @@
     "required": "Tell us whether the {{valuesEnriched.tenantType}} came to the UK before 1988"
   },
   "extra-tenant-pob": {
-    "required": "Enter a place of birth"
+    "required": "Enter a place of birth",
+    "notUrl": "Your answer must not contain URLs or links"
   },
   "extra-tenant-ni-num": {
     "required": "Enter a National Insurance number",
     "niNumber": "Enter a National Insurance number in the correct format"
   },
   "extra-tenant-email": {
-    "email": "Enter a real email address"
+    "email": "Enter a real email address",
+    "minlength": "Email address must be between 6 and 254 characters",
+    "maxlength": "Email address must be between 6 and 254 characters"
   },
   "date-tenant-moved-uk": {
     "required": "Enter a date the {{valuesEnriched.tenantType}} came to the UK",
@@ -54,10 +59,22 @@
     "internationalPhoneNumber": "Enter a real telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
   },
   "tenant-address-line-1": {
-    "required": "Enter address line 1, typically the building and street"
+    "required": "Enter address line 1, typically the building and street",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 1 must be between 1 and 250 characters"
+  },
+  "tenant-address-line-2": {
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 2 must be between 1 and 250 characters"
   },
   "tenant-town-or-city": {
-    "required": "Enter a town or city" 
+    "required": "Enter a town or city",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Town or city must be between 1 and 250 characters"
+  },
+  "tenant-county": {
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "County must be between 1 and 250 characters"
   },
   "tenant-postcode": {
     "required": "Enter a postcode",
@@ -65,14 +82,18 @@
   },
   "landlord-or-agent-name": {
     "required": "Enter a full name",
-    "maxLength": "Name must be 250 characters or less"
+    "maxLength": "Name must be 250 characters or less",
+    "notUrl": "Your answer must not contain URLs or links"
   },
   "landlord-or-agent-company": {
-    "maxLength": "Company name must be 250 characters or less"
+    "maxLength": "Company name must be 250 characters or less",
+    "notUrl": "Your answer must not contain URLs or links"
   },
   "landlord-or-agent-email": {
     "required": "Enter an email address",
-    "email": "Enter a real email address"
+    "email": "Enter a real email address",
+    "minlength": "Email address must be between 6 and 254 characters",
+    "maxlength": "Email address must be between 6 and 254 characters"
   },
   "landlord-or-agent-tel": {
     "internationalPhoneNumber": "Enter a real telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"

--- a/apps/lcs/views/content/what-counts-as-a-home-office-reference-number.md
+++ b/apps/lcs/views/content/what-counts-as-a-home-office-reference-number.md
@@ -10,6 +10,6 @@
   - biometric residence permit number 
   - passport number (current or expired) 
   - Home Office application reference number 
-  - any tracking reference number 
+  - Any tracking reference number 
     </div>
   </details>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -10,3 +10,14 @@ document.querySelectorAll('.typeahead').forEach(function applyTypeahead(element)
     selectElement: element
   });
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const loaderContainer = document.querySelector('#loader-container');
+  const reportSubmitButton = document.querySelector('#report-submit');
+  if (loaderContainer) {
+    document.querySelector('#report-submit .govuk-button').addEventListener('click', () => {
+      loaderContainer.classList.add('spinner-loader');
+      reportSubmitButton.classList.add('visuallyhidden');
+    });
+  }
+});

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -37,6 +37,15 @@ p a[href] {
     font-weight: normal;
 }
 
+.spinner-loader {
+  border: 5px solid #DEE0E2;
+  border-radius: 50%;
+  border-top-color: #005EA5;
+  width: 30px;
+  height: 30px;
+  animation: spin 1s linear infinite;
+}
+
 // Accessible autocomplete
 .autocomplete__wrapper {
     position: relative;

--- a/config.js
+++ b/config.js
@@ -17,7 +17,8 @@ module.exports = {
     notifyApiKey: process.env.NOTIFY_KEY,
     caseworkerEmail: process.env.CASEWORKER_EMAIL,
     userConfirmationTemplateId: process.env.USER_CONFIRMATION_TEMPLATE_ID,
-    businessConfirmationTemplateId: process.env.BUSINESS_CONFIRMATION_TEMPLATE_ID
+    businessConfirmationTemplateId: process.env.BUSINESS_CONFIRMATION_TEMPLATE_ID,
+    replyToEmailID: process.env.REPLY_TO_EMAIL_ID
   },
   startOf1988: '1988-01-01'
 };

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,4 +1,5 @@
 const translation = require('../apps/lcs/translations/src/en/fields.json');
+const config = require('../config.js');
 
 const getLabel = (fieldKey, fieldValue) => {
   if (Array.isArray(fieldValue)) {
@@ -7,4 +8,21 @@ const getLabel = (fieldKey, fieldValue) => {
   return translation[fieldKey].options[fieldValue].label;
 };
 
-module.exports = { getLabel };
+/**
+ * Checks if the user should be redirected to the '/before-1988' page based on the tenant's date of birth.
+ *
+ * @param {string} tenantDob - The tenant's date of birth in ISO format.
+ * @param {string} startOf1988 - The start date of year 1988 in ISO format.
+ * @returns {boolean} - Returns true if the tenant's DOB is before the start of 1988 and not equal to the excluded date.
+ */
+const shouldRedirectToBefore1988 = tenantDob => {
+  const excludedDate = '1987-12-31';
+  /**
+   * If the tenant's date of birth is before the cutoff date and not equal to 1987-12-31,
+   * then redirect to '/before-1988'. This allows tenants born on 1987-12-30 to enter
+   * 1987-12-31 as their date of entry to the UK on the '/extra-tenant-details' page and progress.
+   */
+  return tenantDob < config.startOf1988 && tenantDob !== excludedDate;
+};
+
+module.exports = { getLabel, shouldRedirectToBefore1988 };


### PR DESCRIPTION
## What?
[TLF-332](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-332)
- Added the reply to email id in gov notify

## Why?
- We are using existing gov notify service for ECS and LCS and the default reply to email address in the service cannot be used for HOF emails.
- So added one more reply to email address in gov notify settings and referred that value from hof-services-config

## How? 
- Added the email unique identifier value in hof-services-config and referred in config.js.
- Reading the replyToEmailID value from config and mapped to the emailReplyToId in sendEmail method in notifyClient

## Anything Else? 
- Added custom-redirect for tenant-details page and added "Been in the UK since before 1988" field in summary page and added some conditions in summary-data-sections.js
- [TLF-337](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-337) - Added notURL validation messages for some fields
- [TLF-336](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-336) - Made changes to the content to align with figma
- [TLF-335](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-335) - Made changes to the field label to align with figma

### Testing
- [x] Local testing passed
- [x] Test Lint Passed in Local

