### PR TITLE
Adding PVC to service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -292,7 +292,7 @@ steps:
     when:
       branch:
         <<: *include_default_branch
-      event: [push, pull_request]
+      event: push
     depends_on:
       - clone_repos
       - image_to_ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -291,7 +291,7 @@ steps:
     when:
       branch:
         <<: *include_default_branch
-      event: push
+      event: [push, pull_request]
     depends_on:
       - clone_repos
       - image_to_ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -286,6 +286,7 @@ steps:
         from_secret: kube_token_prod
       REDIS_PERSISTENCE_ENABLED: "true"
       REDIS_PERSISTENCE_SIZE: 1Gi
+      REDIS_PERSISTENCE_STORAGE_CLASS: gp2-encrypted
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:
@@ -338,6 +339,7 @@ steps:
         from_secret: KUBE_TOKEN_PROD
       REDIS_PERSISTENCE_ENABLED: "true"
       REDIS_PERSISTENCE_SIZE: 10Gi
+      REDIS_PERSISTENCE_STORAGE_CLASS: gp2-encrypted
     commands:
       - bin/deploy.sh $${PROD_ENV}
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -284,6 +284,8 @@ steps:
         from_secret: kube_server_prod
       KUBE_TOKEN:
         from_secret: kube_token_prod
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 1Gi
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:
@@ -334,6 +336,8 @@ steps:
         from_secret: KUBE_SERVER_PROD
       KUBE_TOKEN:
         from_secret: KUBE_TOKEN_PROD
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 10Gi
     commands:
       - bin/deploy.sh $${PROD_ENV}
     when:

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -8,12 +8,40 @@ export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+deploy_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd -f kube/redis/redis-pvc.yml
+  fi
+
+  $kd -f kube/redis/redis-config.yml
+  $kd -f kube/redis/redis-service.yml
+  $kd -f kube/redis/redis-network-policy.yml
+  $kd -f kube/redis/redis-deployment.yml
+}
+
+delete_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd --delete -f kube/redis/redis-pvc.yml
+  fi
+
+  $kd --delete -f kube/redis/redis-deployment.yml
+  $kd --delete -f kube/redis/redis-network-policy.yml
+  $kd --delete -f kube/redis/redis-service.yml
+  $kd --delete -f kube/redis/redis-config.yml
+}
+
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  export REDIS_PERSISTENCE_ENABLED="false"
+  export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+  export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-}
+  export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+  export REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/app
+  delete_redis
+  $kd --delete -f kube/app
   echo "Torn Down UAT Branch - lcs-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0
 fi
@@ -21,22 +49,39 @@ fi
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
+export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-false}
+export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-}
+export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+export REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
+
+if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED="true"
+  export REDIS_PERSISTENCE_SIZE="10Gi"
+elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED="true"
+  export REDIS_PERSISTENCE_SIZE="1Gi"
+else
+  export REDIS_PERSISTENCE_ENABLED="false"
+fi
+
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/app
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  $kd -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/redis
+  deploy_redis
   $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -9,6 +9,8 @@ metadata:
   {{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -49,4 +51,16 @@ spec:
               memory: "200Mi"
       volumes:
         - name: data
+          {{ if .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+          persistentVolumeClaim:
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+          {{ else if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+          persistentVolumeClaim:
+            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            claimName: redis-data-{{ .DRONE_SOURCE_BRANCH }}
+            {{ else }}
+            claimName: redis-data
+            {{ end }}
+          {{ else }}
           emptyDir: {}
+          {{ end }}

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -31,6 +31,8 @@ spec:
         app: redis
         {{ end }}
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
         - name: redis
           # redis:v7.0.15
@@ -42,6 +44,8 @@ spec:
               name: data
           securityContext:
             runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
           resources:
             requests:
               cpu: "20m"

--- a/kube/redis/redis-pvc.yml
+++ b/kube/redis/redis-pvc.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: redis-data-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: redis-data
+  {{ end }}
+spec:
+  accessModes:
+    - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}
+  {{ if .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  storageClassName: {{ .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  {{ end }}
+  resources:
+    requests:
+      storage: {{ .REDIS_PERSISTENCE_SIZE }}


### PR DESCRIPTION
## What? 
This pull request adds support for persistent storage for Redis deployments in Kubernetes, replacing ephemeral storage with persistent volumes and claims. It introduces new configuration files for `PersistentVolume` and `PersistentVolumeClaim` resources, and updates the Redis deployment to use these resources. The configuration is dynamic, supporting different environments (production, branch, etc.) with conditional naming and storage sizes.

Persistent storage support for Redis:

* Added `redis-persistent-volume.yml` to define a `PersistentVolume` with conditional naming and storage size based on the environment.
* Added `redis-persistent-volume-claim.yml` to define a `PersistentVolumeClaim` with conditional naming, storage class, and volume binding, supporting different sizes for production and non-production environments.
* Updated `redis-deployment.yml` to use a `persistentVolumeClaim` for the Redis data volume instead of an `emptyDir`, with claim names set dynamically based on the environment.
## Why? 
PersistentVolume ensures that data (like Redis cache/session state) survives pod restarts, rescheduling, or crashes — without it, everything stored in the container is lost the moment it stops running.

## How? 
Config changes

## Testing?
Restart pods and observe behaviour

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
